### PR TITLE
Implement rate limiter module

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,14 @@
+# Architecture
+
+This project syncs Notion pages with a retrieval augmented generation (RAG) layer
+and ChatGPT. The flow is illustrated below.
+
+```mermaid
+graph TD
+    A[Notion] -->|SyncCommand| B(RAG Store)
+    B -->|Context| C[GPT]
+    C -->|Response| A
+```
+
+The RAG store defaults to an in-memory implementation but can be replaced with
+external services like Chroma or Pinecone.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,7 +1,7 @@
-import eslintPluginTs from '@typescript-eslint/eslint-plugin';
-import eslintParserTs from '@typescript-eslint/parser';
+const eslintPluginTs = require('@typescript-eslint/eslint-plugin');
+const eslintParserTs = require('@typescript-eslint/parser');
 
-export default [
+module.exports = [
   {
     files: ['**/*.ts'],
     languageOptions: {

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -3,7 +3,10 @@ import type { Config } from 'jest';
 const config: Config = {
   preset: 'ts-jest',
   testEnvironment: 'node',
-  roots: ['<rootDir>/tests']
+  roots: ['<rootDir>/tests'],
+  transform: {
+    '^.+\\.ts$': 'ts-jest'
+  }
 };
 
 export default config;

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@typescript-eslint/eslint-plugin": "^7.8.0",
         "@typescript-eslint/parser": "^7.8.0",
         "eslint": "^8.56.0",
+        "eslint-compat-utils": "^0.2.1",
         "jest": "^29.7.0",
         "ts-jest": "^29.1.1",
         "ts-node": "^10.9.2",
@@ -2400,6 +2401,22 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-compat-utils": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-compat-utils/-/eslint-compat-utils-0.2.1.tgz",
+      "integrity": "sha512-+0mhJhMeVaiMrgtltweI3sThf8g9VSZKVNSna6gdULUycp9HmcTvcYTw+b7YY+OUHAPXmRiJ9fvsDFnQq9i//A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "eslint": ">=6.0.0"
       }
     },
     "node_modules/eslint-scope": {

--- a/package.json
+++ b/package.json
@@ -1,10 +1,9 @@
 {
   "name": "gpt-notion",
   "version": "0.1.0",
-  "type": "module",
   "scripts": {
     "build": "tsc -p tsconfig.json",
-    "lint": "eslint . --ext .ts",
+    "lint": "eslint .",
     "test": "jest"
   },
   "devDependencies": {
@@ -12,6 +11,7 @@
     "@typescript-eslint/eslint-plugin": "^7.8.0",
     "@typescript-eslint/parser": "^7.8.0",
     "eslint": "^8.56.0",
+    "eslint-compat-utils": "^0.2.1",
     "jest": "^29.7.0",
     "ts-jest": "^29.1.1",
     "ts-node": "^10.9.2",

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  semi: true,
+  singleQuote: true,
+  trailingComma: 'none'
+};

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# Setup script for Codex/CI
+set -euo pipefail
+npm ci --no-audit --progress=false

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,7 @@
+export { RateLimiter, retryOn429 } from './rateLimiter';
+export { TokenCostLogger } from './tokenLogger';
+export { initOTEL } from './otel';
+
 export function placeholder(): string {
   return 'hello world';
 }

--- a/src/otel.ts
+++ b/src/otel.ts
@@ -1,0 +1,3 @@
+export function initOTEL(): void {
+  console.log('OTEL exporter initialized (stdout)');
+}

--- a/src/rateLimiter.ts
+++ b/src/rateLimiter.ts
@@ -1,0 +1,59 @@
+export class RateLimiter {
+  private tokens: number;
+  private readonly interval: NodeJS.Timer;
+  private queue: Array<() => void> = [];
+
+  constructor(private requestsPerMinute: number, private windowMs = 60000) {
+    this.tokens = requestsPerMinute;
+    const refillMs = windowMs / requestsPerMinute;
+    this.interval = setInterval(() => this.refill(), refillMs);
+  }
+
+  private refill(): void {
+    if (this.tokens < this.requestsPerMinute) {
+      this.tokens++;
+    }
+    while (this.tokens > 0 && this.queue.length) {
+      this.tokens--;
+      const job = this.queue.shift();
+      job?.();
+    }
+  }
+
+  async schedule<T>(fn: () => Promise<T>): Promise<T> {
+    if (this.tokens > 0) {
+      this.tokens--;
+      return fn();
+    }
+    return new Promise<T>((resolve, reject) => {
+      this.queue.push(() => {
+        fn().then(resolve).catch(reject);
+      });
+    });
+  }
+
+  stop(): void {
+    clearInterval(this.interval);
+  }
+}
+
+export async function retryOn429<T>(
+  fn: () => Promise<T>,
+  retries = 5,
+  initialDelayMs = 3000
+): Promise<T> {
+  let delay = initialDelayMs;
+  for (let attempt = 0; attempt <= retries; attempt++) {
+    try {
+      return await fn();
+    } catch (err: any) {
+      if (err?.status === 429 && attempt < retries) {
+        await new Promise((r) => setTimeout(r, delay));
+        delay *= 2;
+        continue;
+      }
+      throw err;
+    }
+  }
+  throw new Error('retryOn429 exhausted retries');
+}

--- a/src/tokenLogger.ts
+++ b/src/tokenLogger.ts
@@ -1,0 +1,12 @@
+export class TokenCostLogger {
+  private total = 0;
+
+  logCost(tokens: number): void {
+    this.total += tokens;
+    console.log(`[TokenCost] +${tokens} tokens (total: ${this.total})`);
+  }
+
+  get totalTokens(): number {
+    return this.total;
+  }
+}

--- a/tests/rateLimiter.test.ts
+++ b/tests/rateLimiter.test.ts
@@ -1,0 +1,33 @@
+import { RateLimiter, retryOn429 } from '../src/rateLimiter';
+
+describe('RateLimiter', () => {
+  test('limits execution rate', async () => {
+    const limiter = new RateLimiter(2, 100); // 2 per 100ms
+    const start = Date.now();
+    await Promise.all([
+      limiter.schedule(async () => 1),
+      limiter.schedule(async () => 2),
+      limiter.schedule(async () => 3)
+    ]);
+    const elapsed = Date.now() - start;
+    expect(elapsed).toBeGreaterThanOrEqual(50); // third call delayed
+    limiter.stop();
+  });
+});
+
+describe('retryOn429', () => {
+  test('retries on 429 with backoff', async () => {
+    let attempts = 0;
+    const result = await retryOn429(async () => {
+      attempts++;
+      if (attempts < 3) {
+        const error: any = new Error('rate limited');
+        error.status = 429;
+        throw error;
+      }
+      return 'ok';
+    }, 3, 10);
+    expect(result).toBe('ok');
+    expect(attempts).toBe(3);
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,13 +1,15 @@
 {
   "compilerOptions": {
     "target": "es2022",
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext",
+    "module": "CommonJS",
+    "moduleResolution": "Node",
     "esModuleInterop": true,
     "strict": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
-    "outDir": "dist"
+    "outDir": "dist",
+    "types": ["node", "jest"],
+    "isolatedModules": true
   },
   "include": ["src/**/*.ts", "tests/**/*.ts", "jest.config.ts"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
## Summary
- add architecture overview documentation with a mermaid diagram
- add scripts/setup.sh for CI environments
- configure eslint, prettier and jest separately
- implement RateLimiter with retryOn429 helper
- add TokenCostLogger and OTEL placeholder
- provide unit tests for rate limiter and retry logic

## Testing
- `npm test --silent`
- `npm run lint --silent`


------
https://chatgpt.com/codex/tasks/task_e_688aa69fe87c8325a1fabc4dad4bddfc