### PR TITLE
Add OpenAI SDK client with rate limiting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
 # GPT-Notion
 
 Full-code solution for ChatGPT-Notion integration
+
+This library includes a small wrapper around the official OpenAI SDK. The
+`OpenAIClient` class handles rate limiting, automatic retries on HTTP 429
+responses and logs token usage via `TokenCostLogger`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,9 @@
     "": {
       "name": "gpt-notion",
       "version": "0.1.0",
+      "dependencies": {
+        "openai": "^5.11.0"
+      },
       "devDependencies": {
         "@types/jest": "^29.5.0",
         "@typescript-eslint/eslint-plugin": "^7.8.0",
@@ -4261,6 +4264,27 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/openai": {
+      "version": "5.11.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-5.11.0.tgz",
+      "integrity": "sha512-+AuTc5pVjlnTuA9zvn8rA/k+1RluPIx9AD4eDcnutv6JNwHHZxIhkFy+tmMKCvmMFDQzfA/r1ujvPWB19DQkYg==",
+      "license": "Apache-2.0",
+      "bin": {
+        "openai": "bin/cli"
+      },
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.23.8"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
       }
     },
     "node_modules/optionator": {

--- a/package.json
+++ b/package.json
@@ -20,5 +20,8 @@
     "ts-jest": "^29.1.1",
     "ts-node": "^10.9.2",
     "typescript": "^5.3.3"
+  },
+  "dependencies": {
+    "openai": "^5.11.0"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 export { RateLimiter, retryOn429 } from './rateLimiter';
 export { TokenCostLogger } from './tokenLogger';
 export { initOTEL } from './otel';
+export { OpenAIClient } from './openaiClient';
 
 export function placeholder(): string {
   return 'hello world';

--- a/src/openaiClient.ts
+++ b/src/openaiClient.ts
@@ -1,0 +1,37 @@
+import OpenAI, { ChatCompletionMessageParam } from 'openai';
+import { RateLimiter, retryOn429 } from './rateLimiter';
+import { TokenCostLogger } from './tokenLogger';
+
+export class OpenAIClient {
+  private client: OpenAI;
+  private limiter: RateLimiter;
+  private logger: TokenCostLogger;
+
+  constructor(
+    apiKey: string,
+    limiter: RateLimiter,
+    logger: TokenCostLogger,
+    client?: OpenAI
+  ) {
+    this.limiter = limiter;
+    this.logger = logger;
+    this.client = client ?? new OpenAI({ apiKey });
+  }
+
+  async chat(
+    messages: ChatCompletionMessageParam[],
+    model = 'gpt-3.5-turbo'
+  ): Promise<string> {
+    return retryOn429(() =>
+      this.limiter.schedule(async () => {
+        const res = await this.client.chat.completions.create({
+          messages,
+          model
+        });
+        const tokens = res.usage?.total_tokens ?? 0;
+        this.logger.logCost(tokens);
+        return res.choices[0]?.message?.content ?? '';
+      })
+    );
+  }
+}

--- a/tests/openaiClient.test.ts
+++ b/tests/openaiClient.test.ts
@@ -1,0 +1,29 @@
+import { OpenAIClient } from '../src/openaiClient';
+import { RateLimiter } from '../src/rateLimiter';
+import { TokenCostLogger } from '../src/tokenLogger';
+
+class FakeOpenAI {
+  chat = {
+    completions: {
+      create: async () => ({
+        choices: [{ message: { content: 'hi' } }],
+        usage: { total_tokens: 5 }
+      })
+    }
+  };
+}
+
+test('OpenAIClient logs token usage', async () => {
+  const limiter = new RateLimiter(10);
+  const logger = new TokenCostLogger();
+  const client = new OpenAIClient(
+    'sk-test',
+    limiter,
+    logger,
+    new FakeOpenAI() as any
+  );
+  const result = await client.chat([{ role: 'user', content: 'hello' }]);
+  expect(result).toBe('hi');
+  expect(logger.totalTokens).toBe(5);
+  limiter.stop();
+});


### PR DESCRIPTION
## Summary
- integrate official OpenAI SDK
- expose `OpenAIClient` that handles rate limits, retries and token logging
- add unit test for new client
- document OpenAI wrapper in README

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688aac8bc154832592018160d5738e68