### PR TITLE
Implement env example with dotenv config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,8 @@
-# Example environment variables
-EXAMPLE_KEY=your_value_here
+# Example configuration for GPT-Notion
+# Copy this file to `.env` and fill in your secrets
+
+OPENAI_API_KEY=
+NOTION_API_KEY=
+NOTION_DATABASE_ID=
+# metrics exporter, defaults to stdout
+OTEL_EXPORTER=stdout

--- a/README.md
+++ b/README.md
@@ -6,4 +6,7 @@ This library includes a small wrapper around the official OpenAI SDK. The
 `OpenAIClient` class handles rate limiting, automatic retries on HTTP 429
 responses and logs token usage via `TokenCostLogger`.
 
+Environment variables are used for API keys and other settings. Copy
+`.env.example` to `.env` and fill in your values before running commands.
+
 See [docs/security.md](docs/security.md) for security guidelines.

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/sdk-metrics": "^2.0.1",
+        "dotenv": "^10.0.0",
         "openai": "^5.11.0"
       },
       "devDependencies": {
@@ -2354,6 +2355,15 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
+      "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/ejs": {

--- a/package.json
+++ b/package.json
@@ -22,8 +22,9 @@
     "typescript": "^5.3.3"
   },
   "dependencies": {
-    "openai": "^5.11.0",
     "@opentelemetry/api": "^1.9.0",
-    "@opentelemetry/sdk-metrics": "^2.0.1"
+    "@opentelemetry/sdk-metrics": "^2.0.1",
+    "dotenv": "^10.0.0",
+    "openai": "^5.11.0"
   }
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,8 @@
+import { config } from 'dotenv';
+
+config();
+
+export const OPENAI_API_KEY = process.env.OPENAI_API_KEY || '';
+export const NOTION_API_KEY = process.env.NOTION_API_KEY || '';
+export const NOTION_DATABASE_ID = process.env.NOTION_DATABASE_ID || '';
+export const OTEL_EXPORTER = process.env.OTEL_EXPORTER || 'stdout';

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ export { RateLimiter, retryOn429 } from './rateLimiter';
 export { TokenCostLogger } from './tokenLogger';
 export { initOTEL } from './otel';
 export { OpenAIClient } from './openaiClient';
+export * as Env from './config';
 
 export function placeholder(): string {
   return 'hello world';

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -1,0 +1,13 @@
+import {
+  OPENAI_API_KEY,
+  NOTION_API_KEY,
+  NOTION_DATABASE_ID,
+  OTEL_EXPORTER
+} from '../src/config';
+
+test('env variables load with defaults', () => {
+  expect(OPENAI_API_KEY).toBe('');
+  expect(NOTION_API_KEY).toBe('');
+  expect(NOTION_DATABASE_ID).toBe('');
+  expect(OTEL_EXPORTER).toBe('stdout');
+});


### PR DESCRIPTION
## Summary
- document env setup in README
- add example variables to `.env.example`
- create `src/config.ts` to load env vars via dotenv
- export config from library entry point
- include tests for environment config
- install `dotenv` dependency

## Testing
- `npm run lint`
- `npm test --silent`
- `npx prettier --write README.md src/index.ts src/config.ts tests/config.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_688aba5568248325903b9330e498b673