### PR TITLE
Add scheduler component

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ export { RateLimiter, retryOn429 } from './rateLimiter';
 export { TokenCostLogger } from './tokenLogger';
 export { initOTEL } from './otel';
 export { OpenAIClient } from './openaiClient';
+export { Scheduler } from './scheduler';
 export * as Env from './config';
 
 export function placeholder(): string {

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -1,0 +1,38 @@
+export type Job = () => Promise<void> | void;
+
+export class Scheduler {
+  private timer?: NodeJS.Timeout;
+  private jobs: Job[] = [];
+  private intervalMs: number;
+
+  constructor(intervalMs: number) {
+    this.intervalMs = intervalMs;
+  }
+
+  add(job: Job): void {
+    this.jobs.push(job);
+  }
+
+  start(): void {
+    if (this.timer) {
+      return;
+    }
+    this.timer = setInterval(async () => {
+      for (const job of this.jobs) {
+        try {
+          await job();
+        } catch (err) {
+          // eslint-disable-next-line no-console
+          console.error('Scheduler job failed', err);
+        }
+      }
+    }, this.intervalMs);
+  }
+
+  stop(): void {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = undefined;
+    }
+  }
+}

--- a/tests/scheduler.test.ts
+++ b/tests/scheduler.test.ts
@@ -1,0 +1,13 @@
+import { Scheduler } from '../src/scheduler';
+
+jest.useFakeTimers();
+
+test('scheduler runs job on interval', () => {
+  const scheduler = new Scheduler(50);
+  const job = jest.fn();
+  scheduler.add(job);
+  scheduler.start();
+  jest.advanceTimersByTime(160);
+  scheduler.stop();
+  expect(job).toHaveBeenCalledTimes(3);
+});


### PR DESCRIPTION
## Summary
- implement a tiny `Scheduler` for periodic jobs
- expose `Scheduler` from main index
- test scheduler behaviour

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688ac0ce9b648325bc6bddac2e9c4705