### PR TITLE
Implement Notion connector and pagination fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,11 @@ Full-code solution for ChatGPT-Notion integration
 
 This library includes a small wrapper around the official OpenAI SDK. The
 `OpenAIClient` class handles rate limiting, automatic retries on HTTP 429
-responses and logs token usage via `TokenCostLogger`.
+responses and logs token usage via `TokenCostLogger`. The default chat model is
+`gpt-4o-mini`.
 
 Environment variables are used for API keys and other settings. Copy
 `.env.example` to `.env` and fill in your values before running commands.
 
-See [docs/security.md](docs/security.md) for security guidelines.
+See [docs/security.md](docs/security.md) for security guidelines. Pricing and
+model limits are documented in [docs/openai.md](docs/openai.md).

--- a/docs/openai.md
+++ b/docs/openai.md
@@ -1,0 +1,11 @@
+# OpenAI Pricing and Limits
+
+This project uses the official OpenAI SDK. The default chat model is `gpt-4o-mini`.
+
+See <https://openai.com/pricing> for up-to-date pricing information. At the time
+of writing `gpt-4o-mini` costs about $0.005 per 1K input tokens and
+$0.015 per 1K output tokens.
+
+Rate limits vary by account tier. The `OpenAIClient` automatically retries with
+exponential backoff starting at 3000&nbsp;ms when it encounters HTTP 429 errors.
+Monitor usage closely to avoid unexpected costs.

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -6,6 +6,13 @@ const config: Config = {
   roots: ['<rootDir>/tests'],
   transform: {
     '^.+\\.ts$': 'ts-jest'
+  },
+  extensionsToTreatAsEsm: ['.ts'],
+  globals: {
+    'ts-jest': { useESM: true }
+  },
+  moduleNameMapper: {
+    '^(\\.{1,2}/.*)\\.js$': '$1'
   }
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,10 +8,12 @@
       "name": "gpt-notion",
       "version": "0.1.0",
       "dependencies": {
+        "@notionhq/client": "^4.0.1",
         "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/sdk-metrics": "^2.0.1",
         "dotenv": "^10.0.0",
-        "openai": "^5.11.0"
+        "openai": "^5.11.0",
+        "p-queue": "^7.4.1"
       },
       "devDependencies": {
         "@types/jest": "^29.5.0",
@@ -1215,6 +1217,15 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@notionhq/client": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@notionhq/client/-/client-4.0.1.tgz",
+      "integrity": "sha512-SdILqiiThECLR2KDUOvl4JqRaJWBwDYaEw/f0qu+G6rKN/QUCkaJ84vN5MgBw1yKsMAsKxBlDazs3Jw6vv2ikA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@opentelemetry/api": {
@@ -2690,6 +2701,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "license": "MIT"
     },
     "node_modules/execa": {
       "version": "5.1.1",
@@ -4409,6 +4426,34 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-queue": {
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-7.4.1.tgz",
+      "integrity": "sha512-vRpMXmIkYF2/1hLBKisKeVYJZ8S2tZ0zEAmIJgdVKP2nq0nh4qCdf8bgw+ZgKrkh71AOCaqzwbJJk1WtdcF3VA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventemitter3": "^5.0.1",
+        "p-timeout": "^5.0.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-timeout": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-5.1.0.tgz",
+      "integrity": "sha512-auFDyzzzGZZZdHz3BtET9VEz0SE/uMEAx7uWfGPucfzEwwe/xH0iVeZibQmANYE/hp9T2+UUZT5m+BKyrDp3Ew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"

--- a/package.json
+++ b/package.json
@@ -22,9 +22,11 @@
     "typescript": "^5.3.3"
   },
   "dependencies": {
+    "@notionhq/client": "^4.0.1",
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/sdk-metrics": "^2.0.1",
     "dotenv": "^10.0.0",
-    "openai": "^5.11.0"
+    "openai": "^5.11.0",
+    "p-queue": "^7.4.1"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ export { RateLimiter, retryOn429 } from './rateLimiter';
 export { TokenCostLogger } from './tokenLogger';
 export { initOTEL } from './otel';
 export { OpenAIClient } from './openaiClient';
+export { NotionConnector } from './notionConnector';
 export { Scheduler } from './scheduler';
 export * as Env from './config';
 

--- a/src/notionConnector.ts
+++ b/src/notionConnector.ts
@@ -1,0 +1,62 @@
+import { Client, collectPaginatedAPI } from '@notionhq/client';
+import type { ListBlockChildrenResponse } from '@notionhq/client/build/src/api-endpoints';
+import type PQueue from 'p-queue';
+
+const MAX_BLOCKS = 1000;
+const MAX_SIZE = 500 * 1024; // bytes
+
+export class NotionConnector {
+  private notion: Client;
+  private queue?: PQueue;
+
+  constructor(apiKey: string, client?: Client) {
+    this.notion = client ?? new Client({ auth: apiKey });
+  }
+
+  private async getQueue(): Promise<PQueue> {
+    if (!this.queue) {
+      const mod = await import('p-queue');
+      const PQ = mod.default;
+      this.queue = new PQ({ concurrency: 1, intervalCap: 3, interval: 1000 });
+    }
+    return this.queue;
+  }
+
+  async listChildrenPaged(
+    blockId: string,
+    startCursor?: string
+  ): Promise<ListBlockChildrenResponse> {
+    const q = await this.getQueue();
+    return q.add(() =>
+      this.notion.blocks.children.list({
+        block_id: blockId,
+        page_size: 100,
+        start_cursor: startCursor
+      })
+    ) as Promise<ListBlockChildrenResponse>;
+  }
+
+  async collectAllChildren(
+    blockId: string
+  ): Promise<ListBlockChildrenResponse> {
+    const results = await collectPaginatedAPI(
+      (args) => this.listChildrenPaged(blockId, args.start_cursor),
+      { start_cursor: undefined }
+    );
+    return { object: 'list', results } as ListBlockChildrenResponse;
+  }
+
+  async appendChildrenChecked(blockId: string, children: any[]): Promise<void> {
+    if (children.length > MAX_BLOCKS) {
+      throw new Error('Cannot write more than 1000 blocks at once');
+    }
+    const size = Buffer.byteLength(JSON.stringify(children), 'utf8');
+    if (size > MAX_SIZE) {
+      throw new Error('Payload exceeds 500KB');
+    }
+    const q = await this.getQueue();
+    await q.add(() =>
+      this.notion.blocks.children.append({ block_id: blockId, children })
+    );
+  }
+}

--- a/src/openaiClient.ts
+++ b/src/openaiClient.ts
@@ -27,7 +27,7 @@ export class OpenAIClient {
 
   async chat(
     messages: ChatCompletionMessageParam[],
-    model = 'gpt-3.5-turbo'
+    model = 'gpt-4o-mini'
   ): Promise<string> {
     return retryOn429(() =>
       this.limiter.schedule(async () => {

--- a/tests/notionConnector.test.ts
+++ b/tests/notionConnector.test.ts
@@ -1,0 +1,53 @@
+import { NotionConnector } from '../src/notionConnector';
+
+jest.mock('p-queue', () => ({
+  __esModule: true,
+  default: class {
+    constructor() {}
+    add<T>(fn: () => Promise<T> | T): Promise<T> {
+      return Promise.resolve().then(fn);
+    }
+  }
+}));
+
+class FakeNotion {
+  blocks = {
+    children: {
+      list: jest.fn(async (opts: any) => {
+        if (!opts.start_cursor) {
+          return {
+            object: 'list',
+            results: [{ id: '1' }],
+            next_cursor: 'b',
+            has_more: true
+          };
+        }
+        return {
+          object: 'list',
+          results: [{ id: '2' }],
+          next_cursor: null,
+          has_more: false
+        };
+      }),
+      append: jest.fn(async () => ({}))
+    }
+  };
+}
+
+test('listChildrenPaged returns page', async () => {
+  const conn = new NotionConnector('secret', new FakeNotion() as any);
+  const page1 = await conn.listChildrenPaged('1');
+  expect(page1.results.length).toBe(1);
+  const all = await conn.collectAllChildren('1');
+  expect(all.results.length).toBe(2);
+});
+
+test('appendChildrenChecked enforces limits', async () => {
+  const fake = new FakeNotion();
+  const conn = new NotionConnector('secret', fake as any);
+  await conn.appendChildrenChecked('1', [{ obj: 'block' }]);
+  expect(fake.blocks.children.append).toBeCalled();
+  await expect(
+    conn.appendChildrenChecked('1', new Array(1001).fill({}))
+  ).rejects.toThrow('Cannot write more than 1000 blocks');
+});


### PR DESCRIPTION
## Summary
- add NotionConnector using p-queue with pagination helpers
- enforce Notion API block/size limits
- expose NotionConnector from package
- default OpenAI model is gpt-4o-mini
- document OpenAI pricing and limits
- support ESM modules in Jest for p-queue
- add tests for NotionConnector

## Testing
- `npm run lint`
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688ad406b5048325bc856aa6bbc8bf62