### PR TITLE
Implement Notion connector features

### DIFF
--- a/src/notionConnector.ts
+++ b/src/notionConnector.ts
@@ -1,4 +1,4 @@
-import { Client, collectPaginatedAPI } from '@notionhq/client';
+import { Client } from '@notionhq/client';
 import type { ListBlockChildrenResponse } from '@notionhq/client/build/src/api-endpoints';
 import type PQueue from 'p-queue';
 
@@ -39,10 +39,13 @@ export class NotionConnector {
   async collectAllChildren(
     blockId: string
   ): Promise<ListBlockChildrenResponse> {
-    const results = await collectPaginatedAPI(
-      (args) => this.listChildrenPaged(blockId, args.start_cursor),
-      { start_cursor: undefined }
-    );
+    const results: any[] = [];
+    let cursor: string | undefined;
+    do {
+      const page = await this.listChildrenPaged(blockId, cursor);
+      results.push(...page.results);
+      cursor = page.next_cursor ?? undefined;
+    } while (cursor);
     return { object: 'list', results } as ListBlockChildrenResponse;
   }
 

--- a/src/otel.ts
+++ b/src/otel.ts
@@ -4,9 +4,14 @@ import {
   MeterProvider,
   PeriodicExportingMetricReader
 } from '@opentelemetry/sdk-metrics';
+import { PrometheusExporter } from '@opentelemetry/exporter-prometheus';
+import { OTEL_EXPORTER } from './config';
 
 export function initOTEL(): void {
-  const exporter = new ConsoleMetricExporter();
+  const exporter =
+    OTEL_EXPORTER === 'prometheus'
+      ? new PrometheusExporter({ startServer: true })
+      : new ConsoleMetricExporter();
   const reader = new PeriodicExportingMetricReader({
     exporter,
     exportIntervalMillis: 1000
@@ -15,5 +20,5 @@ export function initOTEL(): void {
     readers: [reader]
   });
   metrics.setGlobalMeterProvider(provider);
-  console.log('OTEL exporter initialized (stdout)');
+  console.log(`OTEL exporter initialized (${OTEL_EXPORTER})`);
 }

--- a/src/ragStore.ts
+++ b/src/ragStore.ts
@@ -1,0 +1,37 @@
+export interface RagResult {
+  id: string;
+  metadata: unknown;
+  score: number;
+}
+
+export interface IRagStore {
+  upsert(id: string, embedding: number[], metadata: unknown): Promise<void>;
+  query(embedding: number[], topK: number): Promise<RagResult[]>;
+}
+
+function distance(a: number[], b: number[]): number {
+  let sum = 0;
+  for (let i = 0; i < Math.min(a.length, b.length); i++) {
+    const diff = a[i] - b[i];
+    sum += diff * diff;
+  }
+  return Math.sqrt(sum);
+}
+
+export class InMemoryRagStore implements IRagStore {
+  private store = new Map<string, { embedding: number[]; metadata: unknown }>();
+
+  async upsert(id: string, embedding: number[], metadata: unknown): Promise<void> {
+    this.store.set(id, { embedding, metadata });
+  }
+
+  async query(embedding: number[], topK: number): Promise<RagResult[]> {
+    const results: RagResult[] = [];
+    for (const [id, entry] of this.store.entries()) {
+      const score = distance(entry.embedding, embedding);
+      results.push({ id, metadata: entry.metadata, score });
+    }
+    results.sort((a, b) => a.score - b.score);
+    return results.slice(0, topK);
+  }
+}

--- a/tests/ragStore.test.ts
+++ b/tests/ragStore.test.ts
@@ -1,0 +1,15 @@
+import { InMemoryRagStore } from '../src/ragStore';
+
+const store = new InMemoryRagStore();
+
+beforeEach(async () => {
+  await store.upsert('a', [0, 0], { text: 'first' });
+  await store.upsert('b', [1, 1], { text: 'second' });
+  await store.upsert('c', [5, 5], { text: 'third' });
+});
+
+test('query returns nearest results', async () => {
+  const results = await store.query([0.1, -0.1], 2);
+  expect(results[0].id).toBe('a');
+  expect(results[1].id).toBe('b');
+});


### PR DESCRIPTION
## Summary
- implement a p‑queue based NotionConnector
- add OTEL Prometheus exporter support
- provide in-memory RAG store
- test new functionality

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_688ade4ed0848325800d42a9de16ac0f