### PR TITLE
Implement notion connector fixes

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -14,7 +14,10 @@ module.exports = [
       prettier: eslintPluginPrettier
     },
     rules: {
-      'no-unused-vars': 'error',
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        { argsIgnorePattern: '^_' }
+      ],
       'prettier/prettier': 'error'
     }
   },

--- a/src/otel.ts
+++ b/src/otel.ts
@@ -1,12 +1,12 @@
 import { metrics } from '@opentelemetry/api';
 import {
-  ConsoleMetricExporter,
   MeterProvider,
   PeriodicExportingMetricReader
 } from '@opentelemetry/sdk-metrics';
+import { PrometheusExporter } from '@opentelemetry/exporter-prometheus';
 
 export function initOTEL(): void {
-  const exporter = new ConsoleMetricExporter();
+  const exporter = new PrometheusExporter();
   const reader = new PeriodicExportingMetricReader({
     exporter,
     exportIntervalMillis: 1000
@@ -15,5 +15,5 @@ export function initOTEL(): void {
     readers: [reader]
   });
   metrics.setGlobalMeterProvider(provider);
-  console.log('OTEL exporter initialized (stdout)');
+  console.log('Prometheus exporter initialized on /metrics');
 }

--- a/src/ragStore.ts
+++ b/src/ragStore.ts
@@ -1,0 +1,46 @@
+export interface RagQueryResult {
+  id: string;
+  score: number;
+  metadata: Record<string, any>;
+}
+
+export interface IRagStore {
+  upsert(
+    id: string,
+    embedding: number[],
+    metadata: Record<string, any>
+  ): Promise<void>;
+  query(embedding: number[], topK: number): Promise<RagQueryResult[]>;
+}
+
+export class InMemoryRagStore implements IRagStore {
+  private items = new Map<
+    string,
+    { embedding: number[]; metadata: Record<string, any> }
+  >();
+
+  async upsert(
+    id: string,
+    embedding: number[],
+    metadata: Record<string, any>
+  ): Promise<void> {
+    this.items.set(id, { embedding, metadata });
+  }
+
+  async query(embedding: number[], topK: number): Promise<RagQueryResult[]> {
+    const results: RagQueryResult[] = [];
+    for (const [id, item] of this.items) {
+      const score = cosineSimilarity(item.embedding, embedding);
+      results.push({ id, score, metadata: item.metadata });
+    }
+    return results.sort((a, b) => b.score - a.score).slice(0, topK);
+  }
+}
+
+function cosineSimilarity(a: number[], b: number[]): number {
+  const dot = a.reduce((sum, val, i) => sum + val * (b[i] ?? 0), 0);
+  const normA = Math.sqrt(a.reduce((sum, val) => sum + val ** 2, 0));
+  const normB = Math.sqrt(b.reduce((sum, val) => sum + val ** 2, 0));
+  const denom = normA * normB;
+  return denom === 0 ? 0 : dot / denom;
+}

--- a/tests/jest.setup.ts
+++ b/tests/jest.setup.ts
@@ -1,15 +1,36 @@
-jest.mock('@notionhq/client', () => {
-  class Client {
-    databases = { query: jest.fn(async () => ({ results: [], has_more: false })) };
-    blocks = { children: { append: jest.fn(async () => ({})) } };
-  }
-  return { Client };
-}, { virtual: true });
-
-jest.mock('p-queue', () => {
-  return class PQueue {
-    add(fn: () => any) {
-      return Promise.resolve().then(fn);
+jest.mock(
+  '@notionhq/client',
+  () => {
+    class Client {
+      databases = {
+        query: jest.fn(async () => ({ results: [], has_more: false }))
+      };
+      blocks = { children: { append: jest.fn(async () => ({})) } };
     }
-  };
-}, { virtual: true });
+    const collectPaginatedAPI = jest.fn(async (fn, { start_cursor }) => {
+      const results: any[] = [];
+      let cursor = start_cursor;
+      while (true) {
+        const page = await fn({ start_cursor: cursor });
+        results.push(...page.results);
+        if (!page.has_more) break;
+        cursor = page.next_cursor;
+      }
+      return results;
+    });
+    return { Client, collectPaginatedAPI };
+  },
+  { virtual: true }
+);
+
+jest.mock(
+  'p-queue',
+  () => {
+    return class PQueue {
+      add(fn: () => any) {
+        return Promise.resolve().then(fn);
+      }
+    };
+  },
+  { virtual: true }
+);

--- a/tests/notionConnector.test.ts
+++ b/tests/notionConnector.test.ts
@@ -1,5 +1,4 @@
 import { NotionConnector } from '../src/notionConnector';
-
 jest.mock('p-queue', () => ({
   __esModule: true,
   default: class {
@@ -13,7 +12,6 @@ jest.mock('p-queue', () => ({
 class FakeNotion {
   blocks = {
     children: {
-
       list: jest.fn(async (opts: any) => {
         if (!opts.start_cursor) {
           return {

--- a/tests/ragStore.test.ts
+++ b/tests/ragStore.test.ts
@@ -1,0 +1,10 @@
+import { InMemoryRagStore } from '../src/ragStore';
+
+test('upsert and query', async () => {
+  const store = new InMemoryRagStore();
+  await store.upsert('a', [1, 0], { title: 'a' });
+  await store.upsert('b', [0, 1], { title: 'b' });
+  const results = await store.query([1, 0], 1);
+  expect(results[0].id).toBe('a');
+  expect(results[0].metadata.title).toBe('a');
+});


### PR DESCRIPTION
## Summary
- add in-memory rag store and query functions
- export Prometheus exporter instead of stdout
- expand Notion mock to support pagination
- lint and format test files

## Testing
- `npm run lint -- --fix`
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_688ae1ba9c9883258095913996ab4f6f