### PR TITLE
Add RAG store and enhance Notion connector

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,11 @@ Full-code solution for ChatGPT-Notion integration
 
 This library includes a small wrapper around the official OpenAI SDK. The
 `OpenAIClient` class handles rate limiting, automatic retries on HTTP 429
-responses and logs token usage via `TokenCostLogger`.
+responses and logs token usage via `TokenCostLogger`. The default model is
+`gpt-4o-mini`.
 
 Environment variables are used for API keys and other settings. Copy
 `.env.example` to `.env` and fill in your values before running commands.
 
-See [docs/security.md](docs/security.md) for security guidelines.
+See [docs/security.md](docs/security.md) for security guidelines. Pricing and
+model limits are documented in [docs/openai.md](docs/openai.md).

--- a/docs/openai.md
+++ b/docs/openai.md
@@ -1,0 +1,6 @@
+# OpenAI Usage
+
+This project uses the official OpenAI SDK. The default chat model is
+`gpt-4o-mini`. Refer to [OpenAI pricing](https://openai.com/pricing) for the
+latest costs. Be mindful of rate limits and token usage when integrating with
+Notion.

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
 # Setup script for Codex/CI
 set -euo pipefail
+NPM_CACHE_DIR="${NPM_CACHE_DIR:-$HOME/.npm}"
+mkdir -p "$NPM_CACHE_DIR"
+npm config set cache "$NPM_CACHE_DIR" --global
 npm ci --no-audit --progress=false --prefer-offline

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,8 @@ export { initOTEL } from './otel';
 export { OpenAIClient } from './openaiClient';
 export { NotionConnector } from './notionConnector';
 export { Scheduler } from './scheduler';
+export { InMemoryRagStore } from './ragStore';
+export type { IRagStore, IRagItem } from './ragStore';
 export * as Env from './config';
 
 export function placeholder(): string {

--- a/src/openaiClient.ts
+++ b/src/openaiClient.ts
@@ -27,7 +27,7 @@ export class OpenAIClient {
 
   async chat(
     messages: ChatCompletionMessageParam[],
-    model = 'gpt-3.5-turbo'
+    model = 'gpt-4o-mini'
   ): Promise<string> {
     return retryOn429(() =>
       this.limiter.schedule(async () => {

--- a/src/ragStore.ts
+++ b/src/ragStore.ts
@@ -1,0 +1,49 @@
+export interface IRagItem {
+  id: string;
+  embedding: number[];
+  metadata: unknown;
+}
+
+/* eslint-disable no-unused-vars */
+export interface IRagStore {
+  upsert(id: string, embedding: number[], metadata: unknown): Promise<void>;
+  query(embedding: number[], topK: number): Promise<IRagItem[]>;
+}
+/* eslint-enable no-unused-vars */
+
+function cosineSimilarity(a: number[], b: number[]): number {
+  let dot = 0;
+  let normA = 0;
+  let normB = 0;
+  for (let i = 0; i < a.length && i < b.length; i++) {
+    dot += a[i] * b[i];
+    normA += a[i] * a[i];
+    normB += b[i] * b[i];
+  }
+  if (!normA || !normB) return 0;
+  return dot / Math.sqrt(normA * normB);
+}
+
+export class InMemoryRagStore implements IRagStore {
+  private store = new Map<string, { embedding: number[]; metadata: unknown }>();
+
+  async upsert(
+    id: string,
+    embedding: number[],
+    metadata: unknown
+  ): Promise<void> {
+    this.store.set(id, { embedding, metadata });
+  }
+
+  async query(embedding: number[], topK: number): Promise<IRagItem[]> {
+    const results: Array<{ id: string; score: number; metadata: unknown }> = [];
+    for (const [id, value] of this.store.entries()) {
+      const score = cosineSimilarity(value.embedding, embedding);
+      results.push({ id, score, metadata: value.metadata });
+    }
+    results.sort((a, b) => b.score - a.score);
+    return results
+      .slice(0, topK)
+      .map((r) => ({ id: r.id, embedding: [], metadata: r.metadata }));
+  }
+}

--- a/src/rateLimiter.ts
+++ b/src/rateLimiter.ts
@@ -51,7 +51,12 @@ export async function retryOn429<T>(
       return await fn();
     } catch (err: any) {
       if (err?.status === 429 && attempt < retries) {
-        await new Promise((r) => setTimeout(r, delay));
+        const headerDelay = Number(
+          err?.headers?.['retry-after'] ??
+            err?.response?.headers?.['retry-after']
+        );
+        const wait = !Number.isNaN(headerDelay) ? headerDelay * 1000 : delay;
+        await new Promise((r) => setTimeout(r, wait));
         delay *= 2;
         continue;
       }

--- a/tests/ragStore.test.ts
+++ b/tests/ragStore.test.ts
@@ -1,0 +1,10 @@
+import { InMemoryRagStore } from '../src/ragStore';
+
+test('upsert and query returns closest items', async () => {
+  const store = new InMemoryRagStore();
+  await store.upsert('1', [1, 0], { title: 'a' });
+  await store.upsert('2', [0, 1], { title: 'b' });
+  const results = await store.query([1, 0], 1);
+  expect(results.length).toBe(1);
+  expect(results[0].id).toBe('1');
+});


### PR DESCRIPTION
## Summary
- create `IRagStore` and an in-memory implementation
- retry Notion API requests on 429 using `retry-after`
- expose rag store exports
- default OpenAI model is `gpt-4o-mini`
- document OpenAI usage and update README
- improve setup script with npm cache
- add tests for the new rag store

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688afb2278c48325ba1be64bcc57450f