### PR TITLE
Update lint workflow with cross-env

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,7 @@ via a Prometheus exporter on `http://localhost:9464/metrics` when
 
 See [docs/security.md](docs/security.md) for security guidelines. Pricing and
 model limits are documented in [docs/openai.md](docs/openai.md).
+
+## Linting
+
+Run `npm run lint` to check the codebase with ESLint.

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "@types/jest": "^29.5.0",
         "@typescript-eslint/eslint-plugin": "^7.8.0",
         "@typescript-eslint/parser": "^7.8.0",
+        "cross-env": "^7.0.3",
         "eslint": "^8.56.0",
         "eslint-compat-utils": "^0.2.1",
         "eslint-config-prettier": "^9.1.2",
@@ -2377,6 +2378,25 @@
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "scripts": {
     "build": "tsc -p tsconfig.json",
-    "lint": "ESLINT_USE_FLAT_CONFIG=true eslint .",
+    "lint": "cross-env ESLINT_USE_FLAT_CONFIG=true eslint .",
     "format": "prettier --write .",
     "test": "jest"
   },
@@ -11,6 +11,7 @@
     "@types/jest": "^29.5.0",
     "@typescript-eslint/eslint-plugin": "^7.8.0",
     "@typescript-eslint/parser": "^7.8.0",
+    "cross-env": "^7.0.3",
     "eslint": "^8.56.0",
     "eslint-compat-utils": "^0.2.1",
     "eslint-config-prettier": "^9.1.2",


### PR DESCRIPTION
## Summary
- add `cross-env` to devDependencies
- run ESLint via `cross-env` so it works cross-platform
- document `npm run lint` in README

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688b1d45b18083259db47f0a6f244059