### PR TITLE
Fix env defaults in tests

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,8 @@
 import { config } from 'dotenv';
 
-config();
+if (process.env.NODE_ENV !== 'test') {
+  config();
+}
 
 export const OPENAI_API_KEY = process.env.OPENAI_API_KEY || '';
 export const NOTION_API_KEY = process.env.NOTION_API_KEY || '';


### PR DESCRIPTION
## Summary
- prevent loading `.env` during test runs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688b27896ba08325ae1d8242487dec8e